### PR TITLE
Ensure uploads folder is created on startup

### DIFF
--- a/app_main.py
+++ b/app_main.py
@@ -10,8 +10,16 @@ from controllers.admin_controller import router as admin_router
 from services.db_service import add_admin_user, verify_admin_user, set_secret_view_password, generate_random_password
 
 app = FastAPI()
+
+# Ensure uploads directory exists before mounting static files
+os.makedirs("uploads", exist_ok=True)
+
 app.mount("/static", StaticFiles(directory="static"), name="static")
-app.mount("/uploads", StaticFiles(directory="uploads"), name="uploads")
+app.mount(
+    "/uploads",
+    StaticFiles(directory="uploads", check_dir=False),
+    name="uploads",
+)
 templates = Jinja2Templates(directory="app_templates")
 
 app.include_router(feedback_router)


### PR DESCRIPTION
## Summary
- create the `uploads` directory before mounting
- mount uploads with `check_dir=False`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c5c5a3a88320b1f1647e1d6a3c9c