### PR TITLE
Return input layout to old style

### DIFF
--- a/app_templates/admin.html
+++ b/app_templates/admin.html
@@ -86,15 +86,15 @@
 
 <!-- Модальні вікна -->
 <div id="addInstitutionModal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-  <div class="bg-white dark:bg-gray-700 rounded-lg shadow-lg w-full max-w-md">
+  <div class="bg-white rounded-lg shadow-lg w-full max-w-md">
     <div id="modal-body" class="p-4 text-center">Завантаження...</div>
   </div>
 </div>
 
 <div id="secretModal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-  <div class="bg-white dark:bg-gray-700 rounded-lg p-6 w-full max-w-md shadow-lg">
+  <div class="bg-white rounded-lg p-6 w-full max-w-md shadow-lg">
     <h2 class="text-lg font-semibold mb-2">Введіть пароль</h2>
-      <input type="password" id="secret-password" class="form-input mb-3" placeholder="Пароль" />
+    <input type="password" id="secret-password" class="w-full mb-3 border px-3 py-2 rounded" placeholder="Пароль" />
     <button id="check-secret-password" class="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700">Показати</button>
     <div id="secret-error" class="text-red-600 mt-2 text-sm"></div>
     <div id="secret-text-display" class="mt-4 whitespace-pre-wrap text-sm text-gray-800"></div>
@@ -104,13 +104,13 @@
 </div>
 
 <div id="changePasswordModal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-  <div class="bg-white dark:bg-gray-700 rounded-lg shadow-lg w-full max-w-md">
+  <div class="bg-white rounded-lg shadow-lg w-full max-w-md">
     <div id="changePasswordModalBody" class="p-4 text-center">Завантаження...</div>
   </div>
 </div>
 
 <div id="statsModal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-  <div class="bg-white dark:bg-gray-700 rounded-lg p-6 w-full max-w-md">
+  <div class="bg-white rounded-lg p-6 w-full max-w-md">
     <h2 class="text-lg font-semibold mb-2">Статистика</h2>
     <div class="mb-2">
       <label for="stats-metric" class="mr-2">Параметр:</label>

--- a/app_templates/attachments_list.html
+++ b/app_templates/attachments_list.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Файли{% endblock %}
 {% block content %}
-<div class="max-w-3xl mx-auto bg-white dark:bg-gray-700 p-6 rounded shadow">
+<div class="max-w-3xl mx-auto bg-white p-6 rounded shadow">
   <h2 class="text-xl font-semibold mb-4">Файли до відгуку {{ feedback_id }}</h2>
   {% if attachments %}
   <ul class="list-disc pl-5 space-y-1">

--- a/app_templates/base.html
+++ b/app_templates/base.html
@@ -7,73 +7,33 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
-      darkMode: 'class',
       theme: {
         extend: {
           colors: {
             primary: '#0d6efd',
-            'primary-dark': '#0a58ca',
             danger: '#dc3545',
             success: '#198754',
-            graylight: '#f8f9fa',
-            graydark: '#343a40'
+            graylight: '#f8f9fa'
           }
         }
       }
     }
   </script>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/style.css">
 </head>
-<body class="bg-gray-100 dark:bg-gray-800 min-h-screen text-gray-800 dark:text-gray-200 transition-colors duration-300">
+<body class="bg-gray-100 min-h-screen text-gray-800">
 
   <!-- Шапка -->
-  <header class="bg-gray-200 dark:bg-graydark shadow px-6 py-4 transition-colors duration-300">
+  <header class="bg-gray-200 shadow px-6 py-4">
     <div class="max-w-6xl mx-auto flex items-center justify-between">
       <a href="/" class="text-3xl font-semibold text-primary select-none hover:no-underline">🛡️ Анонімна система відгуків</a>
-      <button id="theme-toggle" class="text-xl px-3 py-1 rounded hover:bg-graylight dark:hover:bg-gray-700">🌓</button>
     </div>
   </header>
 
   <!-- Контент -->
-  <main class="max-w-5xl mx-auto px-4 py-6 mt-6 bg-gray-50 dark:bg-gray-700 rounded-lg shadow transition-colors duration-300">
+  <main class="max-w-5xl mx-auto px-4 py-6 mt-6 bg-gray-50 rounded-lg shadow">
     {% block content %}{% endblock %}
   </main>
-
-  <div id="toast" class="hidden fixed top-4 right-4 px-4 py-2 rounded shadow text-white"></div>
-
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const htmlEl = document.documentElement;
-      if (localStorage.getItem('theme') === 'dark') {
-        htmlEl.classList.add('dark');
-      }
-      const toggle = document.getElementById('theme-toggle');
-      if (toggle) {
-        toggle.addEventListener('click', () => {
-          htmlEl.classList.toggle('dark');
-          localStorage.setItem('theme', htmlEl.classList.contains('dark') ? 'dark' : 'light');
-        });
-      }
-
-      const message = localStorage.getItem('toastMessage');
-      if (message) {
-        const type = localStorage.getItem('toastType');
-        const toast = document.getElementById('toast');
-        toast.textContent = message;
-        toast.classList.remove('hidden');
-        toast.classList.add(type === 'error' ? 'bg-danger' : 'bg-success');
-        setTimeout(() => {
-          toast.classList.add('hidden');
-          toast.classList.remove('bg-danger', 'bg-success');
-        }, 4000);
-        localStorage.removeItem('toastMessage');
-        localStorage.removeItem('toastType');
-      }
-    });
-  </script>
 
 </body>
 </html>

--- a/app_templates/change_password.html
+++ b/app_templates/change_password.html
@@ -3,7 +3,7 @@
   hx-post="/admin/change_password"
   hx-target="#changePasswordModalBody"
   hx-swap="innerHTML"
-  class="bg-white dark:bg-gray-700 p-6 rounded-lg shadow-lg space-y-4 max-w-lg mx-auto"
+  class="bg-white p-6 rounded-lg shadow-lg space-y-4 max-w-md mx-auto"
 >
   <h2 class="text-xl font-semibold text-gray-800">Змінити пароль</h2>
 
@@ -14,7 +14,7 @@
       name="old_password"
       id="old_password"
       required
-      class="form-input mt-1"
+      class="mt-1 block w-full border border-gray-300 px-3 py-2 rounded focus:outline-none focus:ring focus:border-blue-300"
     />
   </div>
 
@@ -25,7 +25,7 @@
       name="new_password"
       id="new_password"
       required
-      class="form-input mt-1"
+      class="mt-1 block w-full border border-gray-300 px-3 py-2 rounded focus:outline-none focus:ring focus:border-blue-300"
     />
   </div>
 
@@ -36,7 +36,7 @@
       name="confirm_password"
       id="confirm_password"
       required
-      class="form-input mt-1"
+      class="mt-1 block w-full border border-gray-300 px-3 py-2 rounded focus:outline-none focus:ring focus:border-blue-300"
     />
   </div>
 

--- a/app_templates/code_input.html
+++ b/app_templates/code_input.html
@@ -3,13 +3,13 @@
 {% block title %}Введіть код інституції{% endblock %}
 
 {% block content %}
-<div class="max-w-4xl mx-auto bg-white dark:bg-gray-700 p-4 sm:p-6 rounded-lg shadow-md">
+<div class="max-w-xl mx-auto bg-white p-6 rounded-lg shadow-md">
   <h2 class="text-xl font-semibold mb-4 text-center">Введіть код інституції або відскануйте QR-код</h2>
 
   <form action="/enter_code" method="post" class="space-y-4">
     <div class="flex items-center gap-2">
       <input type="text" id="code-input" name="code"
-             class="form-input"
+             class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
              placeholder="Введіть код або скануйте" required autocomplete="off" />
       <button type="button" id="start-qr-scan-btn" title="Сканувати QR"
               class="px-3 py-2 border rounded bg-gray-100 hover:bg-gray-200 text-lg">📷</button>

--- a/app_templates/error.html
+++ b/app_templates/error.html
@@ -1,9 +1,12 @@
 {% extends "base.html" %}
+
 {% block title %}Помилка{% endblock %}
+
 {% block content %}
-<script>
-  localStorage.setItem('toastMessage', '{{ error|escapejs }}');
-  localStorage.setItem('toastType', 'error');
-  window.location.href = '/';
-</script>
+<div class="flex flex-col items-center justify-center text-center bg-white p-8 rounded-lg shadow max-w-lg mx-auto">
+  <h3 class="text-2xl font-semibold text-danger mb-4">❌ Сталася помилка</h3>
+  <p class="text-gray-700">{{ error }}</p>
+
+  <a href="/" class="mt-6 inline-block bg-gray-300 hover:bg-gray-400 text-black px-5 py-2 rounded shadow">← Назад</a>
+</div>
 {% endblock %}

--- a/app_templates/feedback_form.html
+++ b/app_templates/feedback_form.html
@@ -3,7 +3,7 @@
 {% block title %}Залиште відгук{% endblock %}
 
 {% block content %}
-<div class="max-w-6xl mx-auto bg-white dark:bg-gray-700 p-4 sm:p-6 rounded-lg shadow">
+<div class="max-w-2xl mx-auto bg-white p-6 rounded-lg shadow">
   <h2 class="text-xl font-semibold mb-4">Залиште відгук для: <strong>{{ official_name }}</strong></h2>
 
   <form action="/submit" method="post" enctype="multipart/form-data" class="space-y-4" id="feedback-form">
@@ -12,7 +12,7 @@
     <!-- Тема -->
     <div>
       <label for="subject" class="block font-medium mb-1">Тема відгуку (до 75 символів)</label>
-      <input type="text" id="subject" name="subject" maxlength="75" class="form-input" required>
+      <input type="text" id="subject" name="subject" maxlength="75" class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary" required>
       <div class="text-sm text-gray-500 mt-1"><span id="subject-count">0</span>/75 символів</div>
     </div>
 
@@ -30,13 +30,13 @@
     <!-- Зміст відгуку -->
     <div>
       <label for="text" class="block font-medium mb-1">Зміст відгуку</label>
-      <textarea id="text" name="text" maxlength="5000" class="form-input" rows="6" required></textarea>
+      <textarea id="text" name="text" maxlength="5000" class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary" rows="6" required></textarea>
     </div>
 
     <!-- Секретний зміст -->
     <div>
       <label for="secret_text" class="block font-medium mb-1">Секретний зміст (не буде видно публічно)</label>
-      <textarea id="secret_text" name="secret_text" maxlength="5000" class="form-input" rows="3" placeholder="(необов'язково)"></textarea>
+      <textarea id="secret_text" name="secret_text" maxlength="5000" class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary" rows="3" placeholder="(необов'язково)"></textarea>
     </div>
 
     <!-- Файли -->

--- a/app_templates/partials/add_institution_form.html
+++ b/app_templates/partials/add_institution_form.html
@@ -22,7 +22,7 @@
       name="official_name"
       id="official_name"
       required
-      class="form-input" />
+      class="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
   </div>
 
   <div class="flex justify-end gap-2">

--- a/app_templates/partials/feedbacks_table.html
+++ b/app_templates/partials/feedbacks_table.html
@@ -1,5 +1,5 @@
 <div id="feedbacks-table" class="overflow-x-auto">
-  <table class="table-fixed w-full bg-white dark:bg-gray-700 border border-gray-200 rounded shadow-sm" style="table-layout: fixed; word-break: break-word;">
+  <table class="table-fixed w-full bg-white border border-gray-200 rounded shadow-sm" style="table-layout: fixed; word-break: break-word;">
     <colgroup>
       <col class="w-[5%]" />
       <col class="w-[15%]" />

--- a/app_templates/success.html
+++ b/app_templates/success.html
@@ -1,9 +1,15 @@
 {% extends "base.html" %}
-{% block title %}Дякуємо{% endblock %}
+
+{% block title %}Дякуємо за відгук{% endblock %}
+
 {% block content %}
-<script>
-  localStorage.setItem('toastMessage', 'Дякуємо за ваш відгук!');
-  localStorage.setItem('toastType', 'success');
-  window.location.href = '/';
-</script>
+<div class="flex flex-col items-center justify-center text-center bg-white p-8 rounded-lg shadow max-w-lg mx-auto">
+  <h3 class="text-2xl font-semibold text-success mb-4">✅ Дякуємо за ваш відгук!</h3>
+
+  <div class="space-y-2 text-sm text-gray-700">
+    <p><strong>Мова:</strong> {{ lang }}</p>
+  </div>
+
+  <a href="/" class="mt-6 inline-block bg-primary hover:bg-blue-700 text-white px-5 py-2 rounded shadow">← Назад</a>
+</div>
 {% endblock %}

--- a/static/style.css
+++ b/static/style.css
@@ -1,5 +1,5 @@
 body {
-  font-family: "Inter", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   background-color: #f9fafb;
 }
 
@@ -15,33 +15,4 @@ textarea {
 .drop-zone-active {
   background-color: #f0f8ff;
   border-color: #0d6efd;
-}
-
-.form-input {
-  width: 100%;
-  border: none;
-  border-radius: 0.375rem;
-  padding: 0.5rem 0.75rem;
-  background-color: #fff;
-  color: #1f2937;
-  transition: background-color 0.3s, color 0.3s, border-color 0.3s, box-shadow 0.3s;
-}
-
-.form-input:focus {
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.5);
-}
-
-.dark .form-input {
-  background-color: #1f2937;
-  border: none;
-  color: #d1d5db;
-}
-
-.dark .form-input:focus {
-  box-shadow: 0 0 0 3px rgba(10, 88, 202, 0.5);
-}
-
-#toast {
-  z-index: 1000;
 }


### PR DESCRIPTION
## Summary
- revert templates and styles to pre-theme layout

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6845fcf8a0188320a38bc8e498258f26