### PR TITLE
Add dark theme with smooth transition

### DIFF
--- a/app_templates/base.html
+++ b/app_templates/base.html
@@ -21,19 +21,34 @@
   </script>
   <link rel="stylesheet" href="/static/style.css">
 </head>
-<body class="bg-gray-100 min-h-screen text-gray-800">
+<body class="min-h-screen">
 
   <!-- Шапка -->
-  <header class="bg-gray-200 shadow px-6 py-4">
+  <header class="shadow px-6 py-4">
     <div class="max-w-6xl mx-auto flex items-center justify-between">
       <a href="/" class="text-3xl font-semibold text-primary select-none hover:no-underline">🛡️ Анонімна система відгуків</a>
+      <button id="theme-toggle" class="border rounded px-2 py-1">🌙</button>
     </div>
   </header>
 
   <!-- Контент -->
-  <main class="max-w-5xl mx-auto px-4 py-6 mt-6 bg-gray-50 rounded-lg shadow">
+  <main class="max-w-5xl mx-auto px-4 py-6 mt-6 rounded-lg shadow">
     {% block content %}{% endblock %}
   </main>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const toggle = document.getElementById('theme-toggle');
+      const stored = localStorage.getItem('theme');
+      if (stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        document.body.classList.add('dark');
+      }
+      toggle.addEventListener('click', () => {
+        document.body.classList.toggle('dark');
+        localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
+      });
+    });
+  </script>
 
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -1,7 +1,41 @@
+:root {
+  --bg-body: #f9fafb;
+  --text-color: #1f2937;
+  --bg-header: #e5e7eb;
+  --bg-content: #f9fafb;
+}
+
+body.dark {
+  --bg-body: #1f2937;
+  --text-color: #f9fafb;
+  --bg-header: #374151;
+  --bg-content: #4b5563;
+}
+
 body {
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  background-color: #f9fafb;
+  background-color: var(--bg-body);
+  color: var(--text-color);
+  transition: background-color 0.3s, color 0.3s;
 }
+
+header {
+  background-color: var(--bg-header);
+  transition: background-color 0.3s;
+}
+
+main {
+  background-color: var(--bg-content);
+  transition: background-color 0.3s;
+}
+
+/* Dark theme overrides for Tailwind utility classes */
+body.dark .bg-white { background-color: #4b5563 !important; }
+body.dark .bg-gray-50 { background-color: #4b5563 !important; }
+body.dark .bg-gray-100 { background-color: #374151 !important; }
+body.dark .bg-gray-200 { background-color: #374151 !important; }
+body.dark .text-gray-800 { color: #f9fafb !important; }
+body.dark .text-gray-700 { color: #e5e7eb !important; }
 
 textarea {
   resize: vertical;


### PR DESCRIPTION
## Summary
- add theme toggle button and dark mode script
- implement color variables and dark mode styles

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845fe5ba26483208138c445ec74c912