### PR TITLE
Fix dark mode input text color

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -37,6 +37,12 @@ body.dark .bg-gray-200 { background-color: #374151 !important; }
 body.dark .text-gray-800 { color: #f9fafb !important; }
 body.dark .text-gray-700 { color: #e5e7eb !important; }
 
+/* Keep input text readable when switching themes */
+body.dark input,
+body.dark textarea {
+  color: #000;
+}
+
 /* Ensure user input text is visible on light backgrounds */
 input,
 textarea {


### PR DESCRIPTION
## Summary
- ensure input and textarea text remain black in dark mode

## Testing
- `python -m py_compile app_main.py $(find controllers -name '*.py') $(find services -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684602f5505883208cb6e2ad80869040