### PR TITLE
Fix select text color constant across themes

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -39,7 +39,8 @@ body.dark .text-gray-700 { color: #e5e7eb !important; }
 
 /* Keep input text readable when switching themes */
 body.dark input,
-body.dark textarea {
+body.dark textarea,
+body.dark select {
   color: #000;
 }
 
@@ -52,6 +53,11 @@ textarea {
 textarea {
   resize: vertical;
   min-height: 120px;
+}
+
+/* Keep select text consistent across themes */
+select {
+  color: #000;
 }
 
 .table td, .table th {


### PR DESCRIPTION
## Summary
- ensure select field text stays black in dark theme

## Testing
- `python -m compileall -q .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6846049ecbfc832093e130835aa70c46