### PR TITLE
Adjust dark theme row hover

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -32,6 +32,7 @@ main {
 /* Dark theme overrides for Tailwind utility classes */
 body.dark .bg-white { background-color: #4b5563 !important; }
 body.dark .bg-gray-50 { background-color: #4b5563 !important; }
+body.dark .hover\:bg-gray-50:hover { background-color: #374151 !important; }
 body.dark .bg-gray-100 { background-color: #374151 !important; }
 body.dark .bg-gray-200 { background-color: #374151 !important; }
 body.dark .text-gray-800 { color: #f9fafb !important; }


### PR DESCRIPTION
## Summary
- dark theme: keep table rows readable on hover by darkening instead of brightening

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68460620a764832091770ad1cc3490e1